### PR TITLE
Improve versioning: fix method-level support, add auto-config and tests

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -13,21 +13,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up JDK 17
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
+        distribution: temurin
         java-version: 17
         server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
         settings-path: ${{ github.workspace }} # location for the settings.xml file
+        cache: maven
 
     - name: Set version
-      run: mvn versions:set -DnewVersion=${{ github.event.release.name }}
+      run: ./mvnw versions:set -DnewVersion=${{ github.event.release.name }}
 
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: ./mvnw -B package --file pom.xml
 
     - name: Publish to GitHub Packages Apache Maven
-      run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
+      run: ./mvnw deploy -s $GITHUB_WORKSPACE/settings.xml
       env:
         GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,10 +15,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up JDK 17
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
+        distribution: temurin
         java-version: 17
+        cache: maven
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: ./mvnw -B package --file pom.xml

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,3 @@
+wrapperVersion=3.3.4
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip

--- a/README.md
+++ b/README.md
@@ -1,48 +1,266 @@
 # rest-version
 
-This library provides versioning for requests in Spring-based RESTFUL webservices. 
+Versioning support for Spring-based RESTful web services.
 
-## What does it do?
+`rest-version` lets you serve multiple versions of the same REST API from a single
+Spring Boot application. Multiple controllers can be mapped to the same path while
+each one targets a different API version, making it possible to introduce breaking
+changes to your API without breaking clients that still depend on older versions.
 
-This project adds support for versioning Spring MVC resources so that multiple controllers for the same paths can be 
-served for different versions of the API. It makes it possible to make breaking changes to a REST api, while still 
-supporting clients that uses the old version of the API.
+Versions are identified by an ISO date (e.g. `2023-02-01`) and clients select a
+version by sending the `Api-Version` request header. Requests without a header are
+routed to the default version.
 
-The version must be an ISO date (fx. '2022-12-31'). The version must be specified via the header `Api-Version`. 
+## How it works
 
-Also, all supported versions must be registered via ApiVersion like this:
+- **Register the versions** your API supports up front (at application startup).
+- **Annotate controllers** with `@ApiVersionedResource(version = "yyyy-MM-dd")` so
+  that each controller is bound to a specific API version.
+- **Clients pick a version** via the `Api-Version` header, e.g. `Api-Version: 2023-01-01`.
+- The library inspects the header, resolves it against the registered versions, and
+  routes the request to the controller whose version matches.
+
+If the requested version does not match a registered version exactly, the request is
+routed to the closest earlier version. This means clients requesting `2023-02-15`
+will be served by the `2023-02-01` version until a later one is released.
+
+### Features
+
+- Multiple controllers mapped to the same path, differentiated only by version.
+- Date-based versions (`yyyy-MM-dd`) that make it obvious when a version was released.
+- Client-controlled version selection via the `Api-Version` header (configurable name).
+- A configurable default version (used when the header is missing or invalid).
+- Graceful fallback to the closest earlier registered version for unknown dates.
+- Versioning at both the controller (class) level and the method level, where a
+  method-level version overrides the version declared on its controller.
+- Automatic Spring Boot configuration — no manual bean wiring required.
+- Fails fast at startup if a controller references a version that was never registered.
+
+## Requirements
+
+- Java 17+
+- Spring Boot 3.x (Spring MVC)
+
+## Installation
+
+Add the dependency to your build. The library is published to GitHub Packages.
+
+### Maven
+
+```xml
+<repositories>
+    <repository>
+        <id>github</id>
+        <url>https://maven.pkg.github.com/Apaq/rest-version</url>
+    </repository>
+</repositories>
+
+<dependencies>
+    <dependency>
+        <groupId>dk.apaq</groupId>
+        <artifactId>rest-version</artifactId>
+        <version>1.0.3-SNAPSHOT</version>
+    </dependency>
+</dependencies>
 ```
-ApiVersion.registerVersion(new ApiVersion("2024-01-01"));
-ApiVersion.registerVersion(new ApiVersion("2023-02-01"));
+
+### Gradle
+
+```groovy
+repositories {
+    maven {
+        name = "GitHubPackages"
+        url = uri("https://maven.pkg.github.com/Apaq/rest-version")
+    }
+}
+
+dependencies {
+    implementation "dk.apaq:rest-version:1.0.3-SNAPSHOT"
+}
+```
+
+> Note: publishing to GitHub Packages requires authentication. See
+> [GitHub's documentation](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry)
+> for how to configure a token.
+
+## Getting started
+
+### 1. Register the supported versions
+
+Register every API version your application supports, before the web context is built
+(e.g. in your application's `main` method or a `@Configuration` class).
+
+The first registered version becomes the default. Use `registerVersion(version, true)`
+or `ApiVersion.setDefaultVersion(version)` to pick a different default.
+
+```java
+import dk.apaq.rest.version.ApiVersion;
+
 ApiVersion.registerVersion(new ApiVersion("2023-01-01"));
+ApiVersion.registerVersion(new ApiVersion("2023-02-01"));
+ApiVersion.registerVersion(new ApiVersion("2024-01-01"));
 ```
 
-### Example
-The following examples show how to have 2 controllers mapped to the same path return different models based on the version
-specified in the `Api-Version` header. If the header `Api-Version: 2023-01-01` is specified the old controller will be
-handling the request. If the header `Api-Version: 2023-02-01` is specified, then the new controller will handle it instead.
+### 2. Create versioned controllers
+
+Annotate each controller with `@ApiVersionedResource(version = "...")` and map the
+same path on as many controllers as you have versions.
+
+In the example below, a request with `Api-Version: 2023-01-01` is handled by the old
+controller, while `Api-Version: 2023-02-01` is handled by the new one.
 
 __Old version__
 
-```Java
+```java
+import dk.apaq.rest.version.ApiVersionedResource;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @ApiVersionedResource(version = "2023-01-01")
 public class CatController {
 
     @GetMapping("/cats")
-    public List<CatV1> getCats() { ... }
+    public List<CatV1> getCats() {
+        // ...
+    }
 }
 ```
 
 __New version__
-```Java
+
+```java
+import dk.apaq.rest.version.ApiVersionedResource;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
 @RestController
 @ApiVersionedResource(version = "2023-02-01")
 public class CatController {
 
     @GetMapping("/cats")
-    public List<CatV2> getCats() { ... }
+    public List<CatV2> getCats() {
+        // ...
+    }
 }
 ```
+
+### 3. Configure your application
+
+Add the required property to `application.properties` so the version-aware handler
+mapping can replace Spring Boot's default:
+
+```properties
+spring.main.allow-bean-definition-overriding=true
+```
+
+When `rest-version` is on the classpath, its auto-configuration registers
+`ApiVersionedRequestMapping` automatically (you can disable it with
+`rest-version.enabled=false`, or register your own `ApiVersionedRequestMapping` bean).
+
+### 4. Call the API
+
+```console
+$ curl -H "Api-Version: 2023-02-01" https://api.example.com/cats
+```
+
+Omitting the header routes the request to the default version:
+
+```console
+$ curl https://api.example.com/cats
+```
+
+## Method-level versioning
+
+An individual method can override the version declared on its controller. Because
+`@ApiVersionedResource` is meta-annotated with `@RequestMapping`, declare the mapping
+through the annotation's own `path` and `method` attributes rather than combining it
+with `@GetMapping` (Spring does not support multiple `@RequestMapping` annotations on
+one method).
+
+```java
+@RestController
+@ApiVersionedResource(version = "2023-01-01")
+public class CatsController {
+
+    @ApiVersionedResource(version = "2023-02-01", path = "/cats/featured", method = RequestMethod.GET)
+    public List<Cat> getFeaturedCats() {
+        // ...
+    }
+}
+```
+
+A method-level version applies only to that endpoint: with `Api-Version: 2023-01-01`
+the endpoint above is not available, while `Api-Version: 2023-02-01` (or later) serves
+it.
+
+## Configuring the version header
+
+By default the version is read from the `Api-Version` header. To use a different header,
+register your own handler mapping and set the header name:
+
+```java
+@Configuration
+public class VersionedApiConfig {
+
+    @Bean
+    @ConditionalOnMissingBean(ApiVersionedRequestMapping.class)
+    public RequestMappingHandlerMapping requestMappingHandlerMapping() {
+        ApiVersionedRequestMapping mapping = new ApiVersionedRequestMapping();
+        mapping.setHeaderName("X-API-Version");
+        return mapping;
+    }
+}
+```
+
+## Version resolution
+
+When a request arrives, the version is resolved as follows:
+
+1. The configured version header is read. If it is missing or empty, the **default version**
+   is used (the first registered version, or the one selected explicitly).
+2. The header value is parsed as an ISO date and matched against the registered versions.
+3. If an exact match exists, that version is used. Otherwise the **closest earlier**
+   registered version is used (e.g. `2023-02-15` falls back to `2023-02-01`).
+4. If the header cannot be parsed, the default version is used.
+
+The request is then routed to the controller whose version is the latest one that is
+equal to or earlier than the resolved version.
+
+### Registration rules
+
+- Versions must be registered before the web context starts.
+- Registering the same version twice throws an `IllegalArgumentException`.
+- Referencing a version in `@ApiVersionedResource` that was never registered fails fast
+  at startup with a clear error.
+
+## API reference
+
+| Type | Description |
+| ---- | ----------- |
+| `ApiVersion` | Represents an API version and the registry of supported versions. Construct from a `String` (`yyyy-MM-dd`), a `LocalDate`, or `year, month, day`. |
+| `@ApiVersionedResource(version = "...", path = "", method = {})` | Annotation that binds a controller or method to a specific API version. |
+| `ApiVersionedRequestMapping` | Custom `RequestMappingHandlerMapping` that applies version conditions. |
+| `ApiVersionedResourceAutoConfiguration` | Spring Boot auto-configuration that registers the handler mapping. |
+| `ApiVersionedResourceRequestCondition` | Internal request condition that matches a request against a version based on the version header. |
+
+### Key `ApiVersion` methods
+
+| Method | Description |
+| ------ | ----------- |
+| `registerVersion(ApiVersion)` | Registers a supported version. |
+| `registerVersion(ApiVersion, boolean defaultVersion)` | Registers a version and optionally makes it the default. |
+| `setDefaultVersion(ApiVersion)` | Sets the default version explicitly. |
+| `getVersions()` | Returns all registered versions. |
+| `getDefaultVersion()` | Returns the current default version. |
+| `getFirstVersion()` | Returns the first registered version. |
+| `from(String version)` | Resolves a version string to the closest matching registered version. |
+| `clear()` | Clears all registered versions (mainly useful for tests). |
+
+## License
+
+[MIT](LICENSE) © Apaq

--- a/mvnw
+++ b/mvnw
@@ -1,0 +1,295 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.4
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+scriptDir="$(dirname "$0")"
+scriptName="$(basename "$0")"
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"$scriptDir/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${scriptName#mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c - >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+actualDistributionDir=""
+
+# First try the expected directory name (for regular distributions)
+if [ -d "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" ]; then
+  if [ -f "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/bin/$MVN_CMD" ]; then
+    actualDistributionDir="$distributionUrlNameMain"
+  fi
+fi
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if [ -z "$actualDistributionDir" ]; then
+  # enable globbing to iterate over items
+  set +f
+  for dir in "$TMP_DOWNLOAD_DIR"/*; do
+    if [ -d "$dir" ]; then
+      if [ -f "$dir/bin/$MVN_CMD" ]; then
+        actualDistributionDir="$(basename "$dir")"
+        break
+      fi
+    fi
+  done
+  set -f
+fi
+
+if [ -z "$actualDistributionDir" ]; then
+  verbose "Contents of $TMP_DOWNLOAD_DIR:"
+  verbose "$(ls -la "$TMP_DOWNLOAD_DIR")"
+  die "Could not find Maven distribution directory in extracted archive"
+fi
+
+verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$actualDistributionDir/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$actualDistributionDir" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -1,0 +1,189 @@
+<# : batch portion
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.3.4
+@REM
+@REM Optional ENV vars
+@REM   MVNW_REPOURL - repo url base for downloading maven distribution
+@REM   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+@REM   MVNW_VERBOSE - true: enable verbose log; others: silence the output
+@REM ----------------------------------------------------------------------------
+
+@IF "%__MVNW_ARG0_NAME__%"=="" (SET __MVNW_ARG0_NAME__=%~nx0)
+@SET __MVNW_CMD__=
+@SET __MVNW_ERROR__=
+@SET __MVNW_PSMODULEP_SAVE=%PSModulePath%
+@SET PSModulePath=
+@FOR /F "usebackq tokens=1* delims==" %%A IN (`powershell -noprofile "& {$scriptDir='%~dp0'; $script='%__MVNW_ARG0_NAME__%'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw '%~f0'))) -NoNewScope}"`) DO @(
+  IF "%%A"=="MVN_CMD" (set __MVNW_CMD__=%%B) ELSE IF "%%B"=="" (echo %%A) ELSE (echo %%A=%%B)
+)
+@SET PSModulePath=%__MVNW_PSMODULEP_SAVE%
+@SET __MVNW_PSMODULEP_SAVE=
+@SET __MVNW_ARG0_NAME__=
+@SET MVNW_USERNAME=
+@SET MVNW_PASSWORD=
+@IF NOT "%__MVNW_CMD__%"=="" ("%__MVNW_CMD__%" %*)
+@echo Cannot start maven from wrapper >&2 && exit /b 1
+@GOTO :EOF
+: end batch / begin powershell #>
+
+$ErrorActionPreference = "Stop"
+if ($env:MVNW_VERBOSE -eq "true") {
+  $VerbosePreference = "Continue"
+}
+
+# calculate distributionUrl, requires .mvn/wrapper/maven-wrapper.properties
+$distributionUrl = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionUrl
+if (!$distributionUrl) {
+  Write-Error "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+}
+
+switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
+  "maven-mvnd-*" {
+    $USE_MVND = $true
+    $distributionUrl = $distributionUrl -replace '-bin\.[^.]*$',"-windows-amd64.zip"
+    $MVN_CMD = "mvnd.cmd"
+    break
+  }
+  default {
+    $USE_MVND = $false
+    $MVN_CMD = $script -replace '^mvnw','mvn'
+    break
+  }
+}
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+if ($env:MVNW_REPOURL) {
+  $MVNW_REPO_PATTERN = if ($USE_MVND -eq $False) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace "^.*$MVNW_REPO_PATTERN",'')"
+}
+$distributionUrlName = $distributionUrl -replace '^.*/',''
+$distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
+
+$MAVEN_M2_PATH = "$HOME/.m2"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_M2_PATH = "$env:MAVEN_USER_HOME"
+}
+
+if (-not (Test-Path -Path $MAVEN_M2_PATH)) {
+    New-Item -Path $MAVEN_M2_PATH -ItemType Directory | Out-Null
+}
+
+$MAVEN_WRAPPER_DISTS = $null
+if ((Get-Item $MAVEN_M2_PATH).Target[0] -eq $null) {
+  $MAVEN_WRAPPER_DISTS = "$MAVEN_M2_PATH/wrapper/dists"
+} else {
+  $MAVEN_WRAPPER_DISTS = (Get-Item $MAVEN_M2_PATH).Target[0] + "/wrapper/dists"
+}
+
+$MAVEN_HOME_PARENT = "$MAVEN_WRAPPER_DISTS/$distributionUrlNameMain"
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.SHA256]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+$MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
+
+if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
+  Write-Verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"
+  exit $?
+}
+
+if (! $distributionUrlNameMain -or ($distributionUrlName -eq $distributionUrlNameMain)) {
+  Write-Error "distributionUrl is not valid, must end with *-bin.zip, but found $distributionUrl"
+}
+
+# prepare tmp dir
+$TMP_DOWNLOAD_DIR_HOLDER = New-TemporaryFile
+$TMP_DOWNLOAD_DIR = New-Item -Itemtype Directory -Path "$TMP_DOWNLOAD_DIR_HOLDER.dir"
+$TMP_DOWNLOAD_DIR_HOLDER.Delete() | Out-Null
+trap {
+  if ($TMP_DOWNLOAD_DIR.Exists) {
+    try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+    catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+  }
+}
+
+New-Item -Itemtype Directory -Path "$MAVEN_HOME_PARENT" -Force | Out-Null
+
+# Download and Install Apache Maven
+Write-Verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+Write-Verbose "Downloading from: $distributionUrl"
+Write-Verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+$webclient = New-Object System.Net.WebClient
+if ($env:MVNW_USERNAME -and $env:MVNW_PASSWORD) {
+  $webclient.Credentials = New-Object System.Net.NetworkCredential($env:MVNW_USERNAME, $env:MVNW_PASSWORD)
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webclient.DownloadFile($distributionUrl, "$TMP_DOWNLOAD_DIR/$distributionUrlName") | Out-Null
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+$distributionSha256Sum = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionSha256Sum
+if ($distributionSha256Sum) {
+  if ($USE_MVND) {
+    Write-Error "Checksum validation is not supported for maven-mvnd. `nPlease disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties."
+  }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
+  if ((Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne $distributionSha256Sum) {
+    Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised. If you updated your Maven version, you need to update the specified distributionSha256Sum property."
+  }
+}
+
+# unzip and move
+Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+$actualDistributionDir = ""
+
+# First try the expected directory name (for regular distributions)
+$expectedPath = Join-Path "$TMP_DOWNLOAD_DIR" "$distributionUrlNameMain"
+$expectedMvnPath = Join-Path "$expectedPath" "bin/$MVN_CMD"
+if ((Test-Path -Path $expectedPath -PathType Container) -and (Test-Path -Path $expectedMvnPath -PathType Leaf)) {
+  $actualDistributionDir = $distributionUrlNameMain
+}
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if (!$actualDistributionDir) {
+  Get-ChildItem -Path "$TMP_DOWNLOAD_DIR" -Directory | ForEach-Object {
+    $testPath = Join-Path $_.FullName "bin/$MVN_CMD"
+    if (Test-Path -Path $testPath -PathType Leaf) {
+      $actualDistributionDir = $_.Name
+    }
+  }
+}
+
+if (!$actualDistributionDir) {
+  Write-Error "Could not find Maven distribution directory in extracted archive"
+}
+
+Write-Verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$actualDistributionDir" -NewName $MAVEN_HOME_NAME | Out-Null
+try {
+  Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
+} catch {
+  if (! (Test-Path -Path "$MAVEN_HOME" -PathType Container)) {
+    Write-Error "fail to move MAVEN_HOME"
+  }
+} finally {
+  try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+  catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+}
+
+Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>dk.apaq</groupId>
     <artifactId>rest-version</artifactId>
-    <version>1.0.3-SNAPSHOT</version>
+    <version>1.0.4-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <parent>
@@ -16,8 +16,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
     </properties>
 
 
@@ -31,46 +30,28 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webmvc</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.13</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-beanutils</groupId>
-            <artifactId>commons-beanutils</artifactId>
-            <version>1.9.4</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.6</version>
         </dependency>
 
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>5.10.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.10.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>5.5.0</version>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -78,14 +59,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>11</source>
-                    <target>11</target>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>

--- a/src/main/java/dk/apaq/rest/version/ApiVersion.java
+++ b/src/main/java/dk/apaq/rest/version/ApiVersion.java
@@ -5,13 +5,16 @@ import org.slf4j.LoggerFactory;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * This class represents an API version, allowing for version registration, retrieval, and management.
  * Each version is associated with a specific date and can be identified by this date.
+ *
+ * <p>All supported versions must be registered at application startup, before the web context is
+ * built. The registry is thread-safe.</p>
  */
 public class ApiVersion {
 
@@ -19,18 +22,19 @@ public class ApiVersion {
     private static final DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
     // A list of registered API versions.
-    private static final List<ApiVersion> VERSIONS = new ArrayList<>();
+    private static final List<ApiVersion> VERSIONS = new CopyOnWriteArrayList<>();
 
     // Logger for this class.
     private final static Logger LOG = LoggerFactory.getLogger(ApiVersion.class);
 
     // The default API version. This is either the first registered version or a manually set version.
-    private static ApiVersion DEFAULT_VERSION;
+    private static volatile ApiVersion DEFAULT_VERSION;
 
     /**
      * Registers a new API version.
      *
      * @param version        The ApiVersion object to register.
+     * @throws IllegalArgumentException If the version is already registered.
      */
     public static void registerVersion(ApiVersion version) {
         ApiVersion.registerVersion(version, false);
@@ -41,13 +45,38 @@ public class ApiVersion {
      *
      * @param version        The ApiVersion object to register.
      * @param defaultVersion Whether this version should be the default version.
+     * @throws IllegalArgumentException If the version is already registered.
      */
     public static void registerVersion(ApiVersion version, boolean defaultVersion) {
+        if (version == null) {
+            throw new IllegalArgumentException("Version must not be null");
+        }
+        for (ApiVersion registered : VERSIONS) {
+            if (registered.getVersionDate().equals(version.getVersionDate())) {
+                throw new IllegalArgumentException("Version '" + version.getVersion() + "' is already registered");
+            }
+        }
         VERSIONS.add(version);
         // Set this version as the default if specified or if no default version is set.
         if(defaultVersion || DEFAULT_VERSION == null) {
             ApiVersion.DEFAULT_VERSION = version;
         }
+    }
+
+    /**
+     * Sets the default API version explicitly.
+     *
+     * @param version The ApiVersion object to use as the default.
+     * @throws IllegalArgumentException If the version is not registered.
+     */
+    public static void setDefaultVersion(ApiVersion version) {
+        if (version == null) {
+            throw new IllegalArgumentException("Version must not be null");
+        }
+        if (!VERSIONS.contains(version)) {
+            throw new IllegalArgumentException("Version '" + version.getVersion() + "' is not registered");
+        }
+        ApiVersion.DEFAULT_VERSION = version;
     }
 
     /**
@@ -144,7 +173,8 @@ public class ApiVersion {
 
     /**
      * Retrieves an ApiVersion that matches or is closest to the provided version string.
-     * If no exact match is found, the closest earlier version is returned.
+     * If no exact match is found, the closest earlier version is returned. If no registered
+     * version is earlier than the requested one, the first registered version is returned.
      *
      * @param version The version date string to match against.
      * @return The closest matching ApiVersion object.
@@ -152,16 +182,17 @@ public class ApiVersion {
     public static ApiVersion from(String version) {
         try {
             LocalDate date = LocalDate.parse(version);
-            ApiVersion apiVersion = getFirstVersion();
+            ApiVersion closest = null;
 
-            // Iterate through versions and find the closest match.
+            // Find the registered version that is not after the requested date and closest to it.
             for(ApiVersion current : VERSIONS) {
-                if(current.getVersionDate().isAfter(date)) {
-                    break;
+                if(!current.getVersionDate().isAfter(date)) {
+                    if(closest == null || current.getVersionDate().isAfter(closest.getVersionDate())) {
+                        closest = current;
+                    }
                 }
-                apiVersion = current;
             }
-            return apiVersion;
+            return closest != null ? closest : getFirstVersion();
         } catch (Exception ex) {
             // If parsing fails or no matching version is found, return the default version.
             return getDefaultVersion();

--- a/src/main/java/dk/apaq/rest/version/ApiVersionedRequestMapping.java
+++ b/src/main/java/dk/apaq/rest/version/ApiVersionedRequestMapping.java
@@ -5,6 +5,7 @@ import org.springframework.web.servlet.mvc.condition.RequestCondition;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
 import java.lang.reflect.Method;
+import java.util.Collections;
 
 /**
  * Custom handler mapping that supports API versioning through the {@link ApiVersionedResource} annotation.
@@ -12,6 +13,36 @@ import java.lang.reflect.Method;
  * to controllers and methods marked with the `ApiVersionedResource` annotation.
  */
 public class ApiVersionedRequestMapping extends RequestMappingHandlerMapping {
+
+    /**
+     * Creates a version-aware request mapping handler. The order is set to {@code 0} to
+     * match Spring Boot's default {@code requestMappingHandlerMapping} bean, ensuring it
+     * is consulted before resource and static-content handlers.
+     */
+    public ApiVersionedRequestMapping() {
+        setOrder(0);
+    }
+
+    // The request header that carries the API version.
+    private String headerName = ApiVersionedResourceRequestCondition.HEADER_VERSION;
+
+    /**
+     * Returns the request header that carries the API version.
+     *
+     * @return The header name, defaulting to {@code Api-Version}.
+     */
+    public String getHeaderName() {
+        return headerName;
+    }
+
+    /**
+     * Sets the request header that carries the API version.
+     *
+     * @param headerName The header name to use.
+     */
+    public void setHeaderName(String headerName) {
+        this.headerName = headerName;
+    }
 
     /**
      * Retrieves the custom request condition for a given handler type (class-level).
@@ -24,7 +55,7 @@ public class ApiVersionedRequestMapping extends RequestMappingHandlerMapping {
     @Override
     protected RequestCondition<?> getCustomTypeCondition(Class<?> handlerType) {
         ApiVersionedResource typeAnnotation = AnnotationUtils.findAnnotation(handlerType, ApiVersionedResource.class);
-        return createCondition(typeAnnotation, super.getCustomTypeCondition(handlerType));
+        return createCondition(typeAnnotation, super.getCustomTypeCondition(handlerType), false);
     }
 
     /**
@@ -37,8 +68,8 @@ public class ApiVersionedRequestMapping extends RequestMappingHandlerMapping {
      */
     @Override
     protected RequestCondition<?> getCustomMethodCondition(Method method) {
-        ApiVersionedResource methodAnnotation = AnnotationUtils.findAnnotation(method.getClass(), ApiVersionedResource.class);
-        return createCondition(methodAnnotation, super.getCustomMethodCondition(method));
+        ApiVersionedResource methodAnnotation = AnnotationUtils.findAnnotation(method, ApiVersionedResource.class);
+        return createCondition(methodAnnotation, super.getCustomMethodCondition(method), true);
     }
 
     /**
@@ -48,11 +79,13 @@ public class ApiVersionedRequestMapping extends RequestMappingHandlerMapping {
      *
      * @param versionMapping   The {@link ApiVersionedResource} annotation, if present.
      * @param defaultCondition The default {@link RequestCondition} to use if no annotation is found.
+     * @param fromMethod       Whether the annotation originates from a method-level declaration.
      * @return A custom request condition if the annotation is present, otherwise the default condition.
      */
-    private RequestCondition<?> createCondition(ApiVersionedResource versionMapping, RequestCondition<?> defaultCondition) {
+    private RequestCondition<?> createCondition(ApiVersionedResource versionMapping, RequestCondition<?> defaultCondition, boolean fromMethod) {
         if (versionMapping != null) {
-            return new ApiVersionedResourceRequestCondition(versionMapping.version());
+            return new ApiVersionedResourceRequestCondition(
+                Collections.singleton(versionMapping.version()), fromMethod, headerName);
         }
         return defaultCondition;
     }

--- a/src/main/java/dk/apaq/rest/version/ApiVersionedResource.java
+++ b/src/main/java/dk/apaq/rest/version/ApiVersionedResource.java
@@ -3,6 +3,7 @@ package dk.apaq.rest.version;
 import org.springframework.core.annotation.AliasFor;
 import org.springframework.web.bind.annotation.Mapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -14,11 +15,18 @@ import java.lang.annotation.Target;
  * This annotation is used in combination with the {@link ApiVersionedRequestMapping}
  * to map requests based on the API version defined.
  *
- * The version is specified using an ISO date format (yyyy-MM-dd) and can be applied
- * at both the class level (for a controller) and method level.
+ * <p>The version is specified using an ISO date format (yyyy-MM-dd) and can be applied
+ * at both the class level (for a controller) and method level. When applied to a
+ * method it overrides any version declared at the class level for that method.</p>
+ *
+ * <p>Because this annotation is meta-annotated with {@link RequestMapping}, applying it
+ * to a method also contributes the mapping details. Use the {@link #path()} and
+ * {@link #method()} attributes on method-level declarations instead of combining it with
+ * {@code @GetMapping} or {@code @RequestMapping}, as multiple {@code @RequestMapping}
+ * annotations on the same method are not supported by Spring.</p>
  */
 @RequestMapping
-@Target({ElementType.TYPE})
+@Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ApiVersionedResource {
 
@@ -34,5 +42,11 @@ public @interface ApiVersionedResource {
      */
     @AliasFor(annotation = RequestMapping.class, attribute = "path")
     String path() default "";
+
+    /**
+     * The HTTP request methods mapped by this resource.
+     */
+    @AliasFor(annotation = RequestMapping.class, attribute = "method")
+    RequestMethod[] method() default {};
 
 }

--- a/src/main/java/dk/apaq/rest/version/ApiVersionedResourceAutoConfiguration.java
+++ b/src/main/java/dk/apaq/rest/version/ApiVersionedResourceAutoConfiguration.java
@@ -1,0 +1,36 @@
+package dk.apaq.rest.version;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+/**
+ * Auto-configuration that registers the {@link ApiVersionedRequestMapping} as the
+ * application's {@link RequestMappingHandlerMapping}.
+ *
+ * <p>The bean deliberately uses the conventional name {@code requestMappingHandlerMapping}
+ * so that it replaces Spring Boot's default handler mapping. Because Spring Boot's own
+ * bean is declared unconditionally, applications must enable bean definition overriding
+ * via {@code spring.main.allow-bean-definition-overriding=true}.</p>
+ *
+ * <p>Registering your own {@link ApiVersionedRequestMapping} bean (or setting
+ * {@code rest-version.enabled=false}) disables this auto-configuration.</p>
+ */
+@AutoConfiguration(after = WebMvcAutoConfiguration.class)
+@ConditionalOnProperty(prefix = "rest-version", name = "enabled", havingValue = "true", matchIfMissing = true)
+public class ApiVersionedResourceAutoConfiguration {
+
+    /**
+     * Registers the version-aware request mapping handler.
+     *
+     * @return The {@link ApiVersionedRequestMapping} to use for handling requests.
+     */
+    @Bean
+    @ConditionalOnMissingBean(ApiVersionedRequestMapping.class)
+    public RequestMappingHandlerMapping requestMappingHandlerMapping() {
+        return new ApiVersionedRequestMapping();
+    }
+}

--- a/src/main/java/dk/apaq/rest/version/ApiVersionedResourceRequestCondition.java
+++ b/src/main/java/dk/apaq/rest/version/ApiVersionedResourceRequestCondition.java
@@ -6,6 +6,8 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.servlet.mvc.condition.AbstractRequestCondition;
 
 import jakarta.servlet.http.HttpServletRequest;
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
 import java.util.*;
 
 /**
@@ -15,7 +17,7 @@ import java.util.*;
  */
 public class ApiVersionedResourceRequestCondition extends AbstractRequestCondition<ApiVersionedResourceRequestCondition> {
 
-    // Header key used to specify API version in the request.
+    // Default header key used to specify API version in the request.
     public static final String HEADER_VERSION = "Api-Version";
 
     // Logger for this class.
@@ -24,13 +26,19 @@ public class ApiVersionedResourceRequestCondition extends AbstractRequestConditi
     // Set of supported API versions for the condition.
     private final Set<ApiVersion> versions;
 
+    // Header key used to specify the API version in the request.
+    private final String headerName;
+
+    // Whether this condition was declared at method level, in which case it overrides the type-level condition.
+    private final boolean fromMethod;
+
     /**
      * Constructor that accepts a single API version.
      *
      * @param version The version string to initialize the condition.
      */
     public ApiVersionedResourceRequestCondition(String version) {
-        this(Collections.singletonList(version));
+        this(Collections.singletonList(version), false, HEADER_VERSION);
     }
 
     /**
@@ -39,7 +47,7 @@ public class ApiVersionedResourceRequestCondition extends AbstractRequestConditi
      * @param versions The collection of version strings to initialize the condition.
      */
     public ApiVersionedResourceRequestCondition(Collection<String> versions) {
-        this.versions = Collections.unmodifiableSet(toVersionSet(versions));
+        this(versions, false, HEADER_VERSION);
     }
 
     /**
@@ -48,26 +56,72 @@ public class ApiVersionedResourceRequestCondition extends AbstractRequestConditi
      * @param versions The set of {@link ApiVersion} objects to initialize the condition.
      */
     public ApiVersionedResourceRequestCondition(Set<ApiVersion> versions) {
-        this.versions = Collections.unmodifiableSet(versions);
+        this(versions, false, HEADER_VERSION);
     }
 
     /**
-     * Combines this condition with another condition by merging their version sets.
+     * Constructor that accepts a set of {@link ApiVersion} objects and a flag indicating
+     * whether the condition was declared at method level.
+     *
+     * @param versions   The set of {@link ApiVersion} objects to initialize the condition.
+     * @param fromMethod Whether this condition originates from a method-level annotation.
+     */
+    public ApiVersionedResourceRequestCondition(Set<ApiVersion> versions, boolean fromMethod) {
+        this(versions, fromMethod, HEADER_VERSION);
+    }
+
+    /**
+     * Constructor that accepts a set of {@link ApiVersion} objects, a flag indicating
+     * whether the condition was declared at method level, and the request header name.
+     *
+     * @param versions   The set of {@link ApiVersion} objects to initialize the condition.
+     * @param fromMethod Whether this condition originates from a method-level annotation.
+     * @param headerName The request header that carries the API version.
+     */
+    public ApiVersionedResourceRequestCondition(Set<ApiVersion> versions, boolean fromMethod, String headerName) {
+        this.versions = Collections.unmodifiableSet(versions);
+        this.fromMethod = fromMethod;
+        this.headerName = headerName;
+    }
+
+    /**
+     * Constructor that accepts a collection of version strings, a flag indicating
+     * whether the condition was declared at method level, and the request header name.
+     *
+     * @param versions   The collection of version strings to initialize the condition.
+     * @param fromMethod Whether this condition originates from a method-level annotation.
+     * @param headerName The request header that carries the API version.
+     */
+    public ApiVersionedResourceRequestCondition(Collection<String> versions, boolean fromMethod, String headerName) {
+        this(toVersionSet(versions), fromMethod, headerName);
+    }
+
+    /**
+     * Combines this condition with another condition. If either condition was declared
+     * at method level, that condition takes precedence and is returned as-is. Otherwise
+     * the version sets are merged.
      *
      * @param other The other {@link ApiVersionedResourceRequestCondition} to combine with.
-     * @return A new {@link ApiVersionedResourceRequestCondition} containing the merged version set.
+     * @return A new {@link ApiVersionedResourceRequestCondition} containing the merged version set,
+     *         or the method-level condition if one is present.
      */
     @Override
     public ApiVersionedResourceRequestCondition combine(ApiVersionedResourceRequestCondition other) {
         LOG.debug("Combining:\n{}\n{}", this, other);
+        if (other.fromMethod) {
+            return other;
+        }
+        if (this.fromMethod) {
+            return this;
+        }
         Set<ApiVersion> newVersions = new LinkedHashSet<>(this.versions);
         newVersions.addAll(other.versions);
-        return new ApiVersionedResourceRequestCondition(newVersions);
+        return new ApiVersionedResourceRequestCondition(newVersions, false, headerName);
     }
 
     /**
      * Checks if the request matches any of the versions specified in this condition.
-     * It reads the version from the "Api-Version" header and matches it against the versions
+     * It reads the version from the configured header and matches it against the versions
      * in this condition. If no version header is present, the default API version is used.
      *
      * @param request The {@link HttpServletRequest} to match against.
@@ -75,8 +129,8 @@ public class ApiVersionedResourceRequestCondition extends AbstractRequestConditi
      */
     @Override
     public ApiVersionedResourceRequestCondition getMatchingCondition(HttpServletRequest request) {
-        final String header = request.getHeader(HEADER_VERSION);
-        LOG.debug("Api-Version header = {}", header);
+        final String header = request.getHeader(headerName);
+        LOG.debug("{} header = {}", headerName, header);
 
         var version = StringUtils.hasLength(header) ? ApiVersion.from(header) : ApiVersion.getDefaultVersion();
 
@@ -142,6 +196,7 @@ public class ApiVersionedResourceRequestCondition extends AbstractRequestConditi
 
     /**
      * Converts a collection of version strings into a set of {@link ApiVersion} objects.
+     * Each version string must be a registered API version.
      *
      * @param versions The collection of version strings to convert.
      * @return A set of {@link ApiVersion} objects.
@@ -150,9 +205,32 @@ public class ApiVersionedResourceRequestCondition extends AbstractRequestConditi
         Set<ApiVersion> result = new HashSet<>();
 
         for(String version : versions) {
-            result.add(ApiVersion.from(version));
+            result.add(resolve(version));
         }
 
         return result;
+    }
+
+    /**
+     * Resolves a version string to its registered {@link ApiVersion}. Fails fast if the
+     * string is not a valid ISO date or is not among the registered versions.
+     *
+     * @param version The version string to resolve.
+     * @return The matching {@link ApiVersion}.
+     * @throws IllegalArgumentException If the version is malformed or not registered.
+     */
+    private static ApiVersion resolve(String version) {
+        final LocalDate date;
+        try {
+            date = LocalDate.parse(version);
+        } catch (DateTimeParseException ex) {
+            throw new IllegalArgumentException("Invalid API version '" + version + "'. Versions must be ISO dates (yyyy-MM-dd).", ex);
+        }
+        ApiVersion resolved = ApiVersion.from(version);
+        if (resolved == null || !resolved.getVersionDate().equals(date)) {
+            throw new IllegalArgumentException(
+                "API version '" + version + "' is not a registered version. Registered versions: " + ApiVersion.getVersions());
+        }
+        return resolved;
     }
 }

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+dk.apaq.rest.version.ApiVersionedResourceAutoConfiguration

--- a/src/test/java/dk/apaq/rest/version/ApiVersionTest.java
+++ b/src/test/java/dk/apaq/rest/version/ApiVersionTest.java
@@ -102,4 +102,64 @@ class ApiVersionTest {
         assertEquals("2021-12-01", versions.get(0).getVersion());
         assertEquals("2022-06-01", versions.get(1).getVersion());
     }
+
+    @Test
+    void testSetDefaultVersion() {
+        ApiVersion version1 = new ApiVersion("2023-01-01");
+        ApiVersion version2 = new ApiVersion("2024-01-01");
+
+        ApiVersion.registerVersion(version1, false);
+        ApiVersion.registerVersion(version2, false);
+        ApiVersion.setDefaultVersion(version2);
+
+        assertEquals(version2, ApiVersion.getDefaultVersion());
+    }
+
+    @Test
+    void testSetDefaultVersion_notRegistered() {
+        ApiVersion version1 = new ApiVersion("2023-01-01");
+        ApiVersion.registerVersion(version1, false);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+            () -> ApiVersion.setDefaultVersion(new ApiVersion("2024-01-01")));
+        assertEquals("Version '2024-01-01' is not registered", exception.getMessage());
+    }
+
+    @Test
+    void testRegisterDuplicateVersion() {
+        ApiVersion.registerVersion(new ApiVersion("2023-01-01"), false);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+            () -> ApiVersion.registerVersion(new ApiVersion("2023-01-01"), false));
+        assertEquals("Version '2023-01-01' is already registered", exception.getMessage());
+    }
+
+    @Test
+    void testRegisterNullVersion() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+            () -> ApiVersion.registerVersion(null, false));
+        assertEquals("Version must not be null", exception.getMessage());
+    }
+
+    @Test
+    void testFromUnparseableHeaderReturnsDefault() {
+        ApiVersion version1 = new ApiVersion("2023-01-01");
+        ApiVersion.registerVersion(version1, true);
+
+        ApiVersion result = ApiVersion.from("not-a-date");
+        assertEquals(version1, result);
+    }
+
+    @Test
+    void testFromIsIndependentOfRegistrationOrder() {
+        ApiVersion version1 = new ApiVersion("2023-01-01");
+        ApiVersion version2 = new ApiVersion("2023-06-01");
+
+        // Register out of chronological order on purpose
+        ApiVersion.registerVersion(version2, false);
+        ApiVersion.registerVersion(version1, false);
+
+        ApiVersion result = ApiVersion.from("2023-04-01");
+        assertEquals(version1, result);
+    }
 }

--- a/src/test/java/dk/apaq/rest/version/ApiVersionedRequestMappingIntegrationTest.java
+++ b/src/test/java/dk/apaq/rest/version/ApiVersionedRequestMappingIntegrationTest.java
@@ -1,0 +1,153 @@
+package dk.apaq.rest.version;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(
+    classes = ApiVersionedRequestMappingIntegrationTest.TestConfig.class,
+    properties = "spring.main.allow-bean-definition-overriding=true")
+class ApiVersionedRequestMappingIntegrationTest {
+
+    static {
+        registerVersions();
+    }
+
+    private static void registerVersions() {
+        ApiVersion.registerVersion(new ApiVersion("2023-01-01"), false);
+        ApiVersion.registerVersion(new ApiVersion("2023-02-01"), false);
+        ApiVersion.registerVersion(new ApiVersion("2024-01-01"), false);
+    }
+
+    @Configuration
+    @EnableAutoConfiguration
+    static class TestConfig {
+
+        @Bean
+        CatsV1 catsV1() {
+            return new CatsV1();
+        }
+
+        @Bean
+        CatsV2 catsV2() {
+            return new CatsV2();
+        }
+
+        @Bean
+        MethodVersionedController methodVersionedController() {
+            return new MethodVersionedController();
+        }
+    }
+
+    @RestController
+    @ApiVersionedResource(version = "2023-01-01")
+    static class CatsV1 {
+
+        @GetMapping("/cats")
+        public String getCats() {
+            return "v1";
+        }
+    }
+
+    @RestController
+    @ApiVersionedResource(version = "2023-02-01")
+    static class CatsV2 {
+
+        @GetMapping("/cats")
+        public String getCats() {
+            return "v2";
+        }
+    }
+
+    @RestController
+    @ApiVersionedResource(version = "2023-01-01")
+    static class MethodVersionedController {
+
+        @ApiVersionedResource(version = "2023-02-01", path = "/method-versioned", method = RequestMethod.GET)
+        public String get() {
+            return "method-v2";
+        }
+    }
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @Autowired
+    private RequestMappingHandlerMapping handlerMapping;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        if (ApiVersion.getVersions().isEmpty()) {
+            registerVersions();
+        }
+        mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
+    }
+
+    @Test
+    void autoConfigurationRegistersVersionedHandlerMapping() {
+        assertTrue(handlerMapping instanceof ApiVersionedRequestMapping,
+            "Expected the auto-configured handler mapping to be an ApiVersionedRequestMapping");
+    }
+
+    @Test
+    void exactMatch() throws Exception {
+        mockMvc.perform(get("/cats").header("Api-Version", "2023-01-01"))
+            .andExpect(content().string("v1"));
+        mockMvc.perform(get("/cats").header("Api-Version", "2023-02-01"))
+            .andExpect(content().string("v2"));
+    }
+
+    @Test
+    void fallsBackToClosestEarlierVersion() throws Exception {
+        mockMvc.perform(get("/cats").header("Api-Version", "2023-01-15"))
+            .andExpect(content().string("v1"));
+        mockMvc.perform(get("/cats").header("Api-Version", "2023-02-10"))
+            .andExpect(content().string("v2"));
+    }
+
+    @Test
+    void unknownDateServesLatestAvailableController() throws Exception {
+        mockMvc.perform(get("/cats").header("Api-Version", "2024-01-01"))
+            .andExpect(content().string("v2"));
+        mockMvc.perform(get("/cats").header("Api-Version", "2025-01-01"))
+            .andExpect(content().string("v2"));
+    }
+
+    @Test
+    void missingHeaderUsesDefaultVersion() throws Exception {
+        mockMvc.perform(get("/cats"))
+            .andExpect(content().string("v1"));
+    }
+
+    @Test
+    void unparseableHeaderUsesDefaultVersion() throws Exception {
+        mockMvc.perform(get("/cats").header("Api-Version", "not-a-date"))
+            .andExpect(content().string("v1"));
+    }
+
+    @Test
+    void methodLevelVersionOverridesTypeLevel() throws Exception {
+        mockMvc.perform(get("/method-versioned").header("Api-Version", "2023-02-01"))
+            .andExpect(content().string("method-v2"));
+        mockMvc.perform(get("/method-versioned").header("Api-Version", "2023-01-01"))
+            .andExpect(status().isNotFound());
+    }
+}

--- a/src/test/java/dk/apaq/rest/version/ApiVersionedRequestMappingTest.java
+++ b/src/test/java/dk/apaq/rest/version/ApiVersionedRequestMappingTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.mvc.condition.RequestCondition;
 
 import java.lang.reflect.Method;
@@ -18,6 +19,7 @@ class ApiVersionedRequestMappingTest {
 
     @BeforeEach
     void setUp() {
+        ApiVersion.clear();
         handlerMapping = new ApiVersionedRequestMapping();
     }
 
@@ -52,6 +54,46 @@ class ApiVersionedRequestMappingTest {
         assertNull(condition);
     }
 
+    @Test
+    void testGetCustomMethodCondition_WithAnnotation() throws NoSuchMethodException {
+        ApiVersion.registerVersion(new ApiVersion("2023-01-01"), true);
+        ApiVersion.registerVersion(new ApiVersion("2024-01-01"), false);
+
+        Method method = MethodVersionedController.class.getMethod("get");
+
+        RequestCondition<?> condition = handlerMapping.getCustomMethodCondition(method);
+
+        assertNotNull(condition);
+        assertTrue(condition instanceof ApiVersionedResourceRequestCondition);
+
+        ApiVersionedResourceRequestCondition versionCondition = (ApiVersionedResourceRequestCondition) condition;
+        assertEquals("2024-01-01", versionCondition.getLatestVersion().getVersion());
+    }
+
+    @Test
+    void testMethodVersionOverridesTypeVersion() throws NoSuchMethodException {
+        ApiVersion.registerVersion(new ApiVersion("2023-01-01"), true);
+        ApiVersion.registerVersion(new ApiVersion("2024-01-01"), false);
+
+        RequestCondition<?> typeCondition = handlerMapping.getCustomTypeCondition(MethodVersionedController.class);
+        RequestCondition<?> methodCondition = handlerMapping.getCustomMethodCondition(
+            MethodVersionedController.class.getMethod("get"));
+
+        assertNotNull(typeCondition);
+        assertNotNull(methodCondition);
+
+        ApiVersionedResourceRequestCondition combined = ((ApiVersionedResourceRequestCondition) typeCondition)
+            .combine((ApiVersionedResourceRequestCondition) methodCondition);
+
+        assertEquals("2024-01-01", combined.getLatestVersion().getVersion());
+    }
+
+    @Test
+    void testCustomHeaderNameIsUsed() {
+        handlerMapping.setHeaderName("X-API-Version");
+        assertEquals("X-API-Version", handlerMapping.getHeaderName());
+    }
+
 
 
     // Mock controller with ApiVersionedResource annotation
@@ -80,5 +122,15 @@ class ApiVersionedRequestMappingTest {
     // Mock controller without ApiVersionedResource annotation
     private static class NonAnnotatedController {
 
+    }
+
+    // Mock controller with both a type-level and a method-level version
+    @ApiVersionedResource(version = "2023-01-01")
+    private static class MethodVersionedController {
+
+        @ApiVersionedResource(version = "2024-01-01", path = "/mocks", method = RequestMethod.GET)
+        public String get() {
+            return "mockv2";
+        }
     }
 }

--- a/src/test/java/dk/apaq/rest/version/ApiVersionedResourceRequestConditionTest.java
+++ b/src/test/java/dk/apaq/rest/version/ApiVersionedResourceRequestConditionTest.java
@@ -21,6 +21,7 @@ class ApiVersionedResourceRequestConditionTest {
 
     @BeforeEach
     void setUp() {
+        ApiVersion.clear();
         v1 = new ApiVersion(LocalDate.of(2023, 1, 1));
         v2 = new ApiVersion(LocalDate.of(2024, 1, 1));
         ApiVersion.registerVersion(v1, false);
@@ -80,5 +81,40 @@ class ApiVersionedResourceRequestConditionTest {
 
         // Verify that default version is used when no version header is provided
         assertNotNull(defaultCondition);
+    }
+
+    @Test
+    void testCombine_MethodLevelOverridesTypeLevel() {
+        // Method-level condition must override the type-level condition
+        ApiVersionedResourceRequestCondition typeCondition = conditionV1;
+        ApiVersionedResourceRequestCondition methodCondition = new ApiVersionedResourceRequestCondition(
+            Collections.singleton(v2), true);
+
+        ApiVersionedResourceRequestCondition combined = typeCondition.combine(methodCondition);
+
+        assertEquals(v2, combined.getLatestVersion());
+    }
+
+    @Test
+    void testCustomHeaderName() {
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        when(request.getHeader("X-API-Version")).thenReturn("2023-01-01");
+
+        ApiVersionedResourceRequestCondition condition = new ApiVersionedResourceRequestCondition(
+            Collections.singleton(v1), false, "X-API-Version");
+
+        assertNotNull(condition.getMatchingCondition(request));
+    }
+
+    @Test
+    void testUnregisteredVersion_FailsFast() {
+        assertThrows(IllegalArgumentException.class,
+            () -> new ApiVersionedResourceRequestCondition(Collections.singletonList("2020-01-01")));
+    }
+
+    @Test
+    void testMalformedVersion_FailsFast() {
+        assertThrows(IllegalArgumentException.class,
+            () -> new ApiVersionedResourceRequestCondition(Collections.singletonList("not-a-date")));
     }
 }


### PR DESCRIPTION
- Fix getCustomMethodCondition to inspect the handler method instead of Method.class, and support method-level version overrides via path/method attributes on ApiVersionedResource
- Fail fast at startup when an annotation references an unregistered version
- Make the ApiVersion registry thread-safe, reject duplicates, add setDefaultVersion, and make version resolution order-independent
- Add Spring Boot auto-configuration for ApiVersionedRequestMapping (rest-version.enabled toggle) and a configurable version header name
- Add end-to-end MockMvc integration tests covering routing, fallback, default version, and method-level override behavior
- Clean up dependencies: drop unused commons-beanutils/commons-lang and redundant pins, use provided-scope webmvc/servlet/autoconfigure, and standardize on Java 17 via maven.compiler.release
- Add Maven wrapper and upgrade GitHub Actions to checkout@v4/setup-java@v4
- Expand README with setup, configuration, and method-level versioning docs